### PR TITLE
Proper Promotion/Underpromotion Support

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,2 +1,4 @@
-Add promotion notation to SAN 
-Allow player to choose piece to promote to.
+Add promotion notation to SAN (DONE)
+Allow player to choose piece to promote to. (DONE)
+Allow player to choose color to play with in swing.
+Have "Configure" do something eventually.

--- a/src/net/animats/chess/ConsoleInterface.java
+++ b/src/net/animats/chess/ConsoleInterface.java
@@ -109,8 +109,8 @@ class ConsoleInterface implements IOInterface {
 					} else if (inputLine.equals("moves")) 
 						DisplayLegalMoves();
 					else if (inputLine.equals("material")) {
-						System.out.println("white material: " + engine.GetCurrentPosition().totalMaterial[Resources.WHITE] + ", black matierial: " + engine.GetCurrentPosition().totalMaterial[Resources.BLACK]);
-						} else if (inputLine.equals("board")) 
+						System.out.println("white material: " + engine.GetCurrentPosition().totalMaterial[Resources.WHITE] + ", black material: " + engine.GetCurrentPosition().totalMaterial[Resources.BLACK]);
+					} else if (inputLine.equals("board")) 
 						UpdateDisplay(engine.GetCurrentPosition());
 					else if (inputLine.equals("restart") || inputLine.equals("new")) {
 						engine.Reset();
@@ -145,9 +145,9 @@ class ConsoleInterface implements IOInterface {
 						if (!inputLine.equals(""))
 							System.out.println(inputLine + " is not a legal command or move\n");
 					}
-    				} catch ( IOException error ) {
-        				System.err.println( "error reading stdin: " + error );
-    				}
+				} catch ( IOException error ) {
+    				System.err.println( "error reading stdin: " + error );
+				}
 			}
 		// Check if the last command typed has ended the game either by resigning or winning
 		// and keeping looping for more user input if the game is still active.

--- a/src/net/animats/chess/Engine.java
+++ b/src/net/animats/chess/Engine.java
@@ -284,14 +284,14 @@ class Engine extends Thread {
 		StringBuilder principalVariation = new StringBuilder();
 		
 		if (_firstMove.madeBy == Resources.BLACK)
-			principalVariation.append(Integer.toString(_firstMove.moveNumber) + "...");
+			principalVariation.append(Integer.toString(_firstMove.MoveNumber()) + "...");
 		
 		Move move = _firstMove;
 		
 		do {
 			if (move.madeBy == Resources.WHITE) {
 				principalVariation.append(" ");
-				principalVariation.append(Integer.toString(move.moveNumber));
+				principalVariation.append(Integer.toString(move.MoveNumber()));
 				principalVariation.append(". ");
 			} else
 				principalVariation.append(" ");
@@ -309,7 +309,7 @@ class Engine extends Thread {
 	}
 
 	/**
-	 * This method sorts the immediate moves that can be makefrom this position into an order based on their 
+	 * This method sorts the immediate moves that can be made from this position into an order based on their
 	 * evaluations. This is done to speed up alpha-beta pruning.
 	 */
 	private void SortMoves() {

--- a/src/net/animats/chess/Move.java
+++ b/src/net/animats/chess/Move.java
@@ -6,11 +6,12 @@ package net.animats.chess;
 class Move implements Comparable<Move> {
 	static final char[] fileLetter = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' };
 	static final char[] rankNumber = { '1', '2', '3', '4', '5', '6', '7', '8' };
-
+	static final char[] promotionLetter = { '\0', '\0', 'n', 'b', 'r', 'q' };
+	static final String[] promotionName = { "knight", "bishop", "rook", "queen" };
+	
 	static final int NOT_CASTLING = 0;
 	static final int QUEEN_SIDE = 1;
 	static final int KING_SIDE = 2;
-	
                 
 	GameState stateAfterMove = GameState.UNKNOWN;
         
@@ -33,7 +34,8 @@ class Move implements Comparable<Move> {
 	Position.Piece pieceTaken;
 	Position.Piece pieceMoved;
 
-	boolean promotedPawn = false;
+	int promotionPiece = 0;
+	boolean pawnPromoted = false;
 	boolean enPassant = false;
 
 	SearchResult result;
@@ -44,13 +46,12 @@ class Move implements Comparable<Move> {
 	int castling = NOT_CASTLING;
 
 	public String toString() {
-		if (pieceTaken == null)
-			return (Algebraic() + " (" + Resources.englishColour[pieceMoved.colour] + " " + pieceMoved.FullName() + " on " + fileLetter[oldFile] + rankNumber[oldRank] + " to " + fileLetter[newFile] + rankNumber[newRank] + ")");
-		else
-			return (Algebraic() + " (" + Resources.englishColour[pieceMoved.colour] + " " + pieceMoved.FullName() + " on " + fileLetter[oldFile] + rankNumber[oldRank] + " takes " + fileLetter[newFile] + rankNumber[newRank] + ")");
+		return (Algebraic() + " (" + Resources.englishColour[pieceMoved.colour] + " " + pieceMoved.FullName() + " on " +
+				fileLetter[oldFile] + rankNumber[oldRank] + ((pieceTaken == null) ? " to " : " takes ") +
+				fileLetter[newFile] + rankNumber[newRank] + ((pawnPromoted) ? (", promotes to " + promotionName[promotionPiece -2]) : "") + ")");
 	}
 
-	Move (int _oldRank, int _oldFile, int _newRank, int _newFile, Position _theBoard) {
+	Move (int _oldRank, int _oldFile, int _newRank, int _newFile, int _promotionPiece, Position _theBoard) {
 		oldRank = _oldRank;
 		oldFile = _oldFile;
 		newRank = _newRank;
@@ -66,6 +67,10 @@ class Move implements Comparable<Move> {
 				// pieceTaken to the pawn to be taken.
 				pieceTaken = _theBoard.getPieceAt(_oldRank, _newFile);
 				enPassant = true;
+			} else if (newRank == 0 || newRank == 7) {
+				// Check for a promotion and act accordingly
+				promotionPiece = _promotionPiece;
+				pawnPromoted = true;
 			}
 		}
 	}
@@ -74,7 +79,7 @@ class Move implements Comparable<Move> {
 		StringBuilder moveString = new StringBuilder();
 		if (madeBy == Resources.BLACK) {
 			moveString.append(Algebraic());
-		}else {
+		} else {
 			moveString.append(MoveNumber());
 			moveString.append(".");
 			moveString.append(Algebraic());
@@ -89,7 +94,7 @@ class Move implements Comparable<Move> {
 		if (madeBy == Resources.BLACK) {
 			moveString.append(". ... ");
 			moveString.append(Algebraic());
-		}else {
+		} else {
 			moveString.append(". ");
 			moveString.append(Algebraic());
 		}
@@ -137,6 +142,10 @@ class Move implements Comparable<Move> {
 		// Display the destination location.
 		move.append(fileLetter[newFile]);
 		move.append(rankNumber[newRank]);
+		
+		// If promotion, append the promotion piece
+		if (pawnPromoted)
+			move.append(("=" + promotionLetter[promotionPiece]).toUpperCase());
 
 		if (stateAfterMove == GameState.WHITE_CHECKMATED || stateAfterMove == GameState.BLACK_CHECKMATED)
 			move.append("#");
@@ -147,7 +156,8 @@ class Move implements Comparable<Move> {
 	}
 
 	public String AsCommand() {
-		return ("" + fileLetter[oldFile] + rankNumber[oldRank] + fileLetter[newFile] + rankNumber[newRank]);
+		return ("" + fileLetter[oldFile] + rankNumber[oldRank] + fileLetter[newFile] + rankNumber[newRank]
+				+ (pawnPromoted ? promotionLetter[promotionPiece] : "") );
 	}
 
 	/**

--- a/src/net/animats/chess/Position.java
+++ b/src/net/animats/chess/Position.java
@@ -328,7 +328,7 @@ class Position {
 				// Set as an empty square by default, then add the pieces...
 				squares[rank][file] = null;
 
-				// Put all the pieces on the first and eigth ranks. Store a pointer to a 
+				// Put all the pieces on the first and eighth ranks. Store a pointer to a
 				// rook, bishop, knight and king for the purpose of determining if the
 				// player is in check.
 				if (rank == 0 || rank == 7) {
@@ -387,10 +387,26 @@ class Position {
 			squares[_move.oldRank][_move.newFile] = null;
 		}
 
-		// Promote the pawn if required and increase the moving players material.
+		// Promote the pawn if required and increase the moving player's material.
 		if (_move.pieceMoved instanceof Pawn && (_move.newRank == 0 || _move.newRank == 7)) {
-			squares[_move.newRank][_move.newFile] = new Queen(_move.pieceMoved.colour);	
-			totalMaterial[_move.pieceMoved.colour] += 800;
+			switch (_move.promotionPiece) {
+				case Piece.KNIGHT:
+					squares[_move.newRank][_move.newFile] = new Knight(_move.pieceMoved.colour);
+					totalMaterial[_move.pieceMoved.colour] += 200;
+					break;
+				case Piece.BISHOP:
+					squares[_move.newRank][_move.newFile] = new Bishop(_move.pieceMoved.colour);
+					totalMaterial[_move.pieceMoved.colour] += 200;
+					break;
+				case Piece.ROOK:
+					squares[_move.newRank][_move.newFile] = new Rook(_move.pieceMoved.colour);
+					totalMaterial[_move.pieceMoved.colour] += 400;
+					break;
+				case Piece.QUEEN:
+					squares[_move.newRank][_move.newFile] = new Queen(_move.pieceMoved.colour);
+					totalMaterial[_move.pieceMoved.colour] += 800;
+					break;
+			}
 		} else {
 			// Move the piece from its old square to the new square.
 			squares[_move.newRank][_move.newFile] = _move.pieceMoved;
@@ -445,7 +461,14 @@ class Position {
 		
 		// Demote the pawn if required and decrease the moving players material.
 		if (lastMove.pieceMoved instanceof Pawn && (lastMove.newRank == 0 || lastMove.newRank == 7)) {
-			totalMaterial[lastMove.pieceMoved.colour] -= 800;
+			if (squares[lastMove.newRank][lastMove.newFile] instanceof Knight)
+				totalMaterial[lastMove.pieceMoved.colour] -= 200;
+			else if (squares[lastMove.newRank][lastMove.newFile] instanceof Bishop)
+				totalMaterial[lastMove.pieceMoved.colour] -= 200;
+			else if (squares[lastMove.newRank][lastMove.newFile] instanceof Rook)
+				totalMaterial[lastMove.pieceMoved.colour] -= 400;
+			else if (squares[lastMove.newRank][lastMove.newFile] instanceof Queen)
+				totalMaterial[lastMove.pieceMoved.colour] -= 800;
 		} 
 
 		// Move the piece from its old square to the new square.
@@ -695,7 +718,7 @@ class Position {
 		public PieceMove[] standardMoves;
 		public boolean moveRepeatable;
 
-		// This abstract method is implented differently by each specific type of piece.
+		// This abstract method is implemented differently by each specific type of piece.
 		// It returns a vector of all the pieces possible standard and special moves.
 		abstract ArrayList<Move> Moves(Position _theBoard, int _rank, int _file);
 
@@ -723,25 +746,25 @@ class Position {
 					workingRank += standardMove.rankOffset;
 					workingFile += standardMove.fileOffset;
 
-					// Discard the move and any further repititions if it takes the piece off the board.
+					// Discard the move and any further repetitions if it takes the piece off the board.
 					if (workingRank < 0 || workingRank > 7 || workingFile < 0 || workingFile > 7)
 						break;
 
 					// Check if the destination square has a piece on it.
 					if (_theBoard.squares[workingRank][workingFile] != null) {
 						if (_theBoard.squares[workingRank][workingFile].colour == this.colour) {
-							// Discard this move and any further repititions as the destination
-							// sqaure contains a piece of the same colour.
+							// Discard this move and any further repetitions as the destination
+							// square contains a piece of the same colour.
 							break;
 						} else {
-							// Accept the current move and ignore any further repititions if 
+							// Accept the current move and ignore any further repetitions if
 							// this move takes an opposing piece.
 							keepRepeating = false;
 						}
 					}
 					
 					// Create a new Move represent the this move
-					Move newMove = new Move(_rank, _file, workingRank, workingFile, _theBoard);
+					Move newMove = new Move(_rank, _file, workingRank, workingFile, 0, _theBoard);
 
 					// Discard this move and any further repetitions if the move results in the
 					// player's king being in check.
@@ -824,24 +847,39 @@ class Position {
 			
 			if (_theBoard.squares[_rank + rankOffset][_file] == null) {	
 				// Create a new Move represent the this move
-				Move newMove = new Move(_rank, _file, _rank + rankOffset, _file, _theBoard);
+				if (_rank + rankOffset != 0 && _rank + rankOffset != 7) {
+					// The pawn does not promote with this move
+					Move newMove = new Move(_rank, _file, _rank + rankOffset, _file, 0, _theBoard);
 
-				// Discard this move and any further repetitions if the move results in the
-				// player's king being in check.
-				if (_theBoard.MoveIntoCheck(newMove) == false)
-					possibleMoves.add(newMove);					
+					// Discard this move and any further repetitions if the move results in the
+					// player's king being in check.
+					if (_theBoard.MoveIntoCheck(newMove) == false)
+						possibleMoves.add(newMove);
+				} else {
+					// The pawn would promote with this move
+					Move newMove = new Move(_rank, _file, _rank + rankOffset, _file, 2, _theBoard);
+					
+					// Discard this move and any further repetitions if the move results in the
+					// player's king being in check.
+					// Otherwise, add the rest of the promotion possibilities to the list of moves.
+					if (_theBoard.MoveIntoCheck(newMove) == false) {
+						possibleMoves.add(newMove);
+						for (int promotionNumber = 3; promotionNumber <= 5; promotionNumber++)
+							possibleMoves.add(new Move(_rank, _file, _rank + rankOffset, _file, promotionNumber, _theBoard));
+					}
+				}
 			}
 
 			// If the two squares 'ahead' are empty and the pawn hasn't yet moved, try moving there.
 			if (moveCount == 0) {
 				if (_theBoard.squares[_rank + rankOffset][_file] == null && _theBoard.squares[_rank + initialRankOffset][_file] == null) {	
 					// Create a new Move represent the this move
-					Move newMove = new Move(_rank, _file, _rank + initialRankOffset, _file, _theBoard);
+					Move newMove = new Move(_rank, _file, _rank + initialRankOffset, _file, 0, _theBoard);
 				
 					// Discard this move and any further repetitions if the move results in the
 					// player's king being in check.
 					if (_theBoard.MoveIntoCheck(newMove) == false)
-						possibleMoves.add(newMove);					
+						possibleMoves.add(newMove);		
 				}
 			}
 			
@@ -849,12 +887,27 @@ class Position {
 			if (_file - 1 > -1) {
 				if (_theBoard.squares[_rank + rankOffset][_file - 1] != null &&  _theBoard.squares[_rank + rankOffset][_file - 1].colour != colour) {
 					// Create a new Move represent the this move
-					Move newMove = new Move(_rank, _file, _rank + rankOffset, _file - 1, _theBoard);
-				
-					// Discard this move and any further repetitions if the move results in the
-					// player's king being in check.
-					if (_theBoard.MoveIntoCheck(newMove) == false)
-						possibleMoves.add(newMove);					
+					if (_rank + rankOffset != 0 && _rank + rankOffset != 7) {
+						// The pawn does not promote this move
+						Move newMove = new Move(_rank, _file, _rank + rankOffset, _file - 1, 0, _theBoard);
+					
+						// Discard this move and any further repetitions if the move results in the
+						// player's king being in check.
+						if (_theBoard.MoveIntoCheck(newMove) == false)
+							possibleMoves.add(newMove);
+					} else {
+						// The pawn would promote with this move
+						Move newMove = new Move(_rank, _file, _rank + rankOffset, _file - 1, 2, _theBoard);
+						
+						// Discard this move and any further repetitions if the move results in the
+						// player's king being in check.
+						// Otherwise, add the rest of the promotion possibilities to the list of moves.
+						if (_theBoard.MoveIntoCheck(newMove) == false) {
+							possibleMoves.add(newMove);
+							for (int promotionNumber = 3; promotionNumber <= 5; promotionNumber++)
+								possibleMoves.add(new Move(_rank, _file, _rank + rankOffset, _file - 1, promotionNumber, _theBoard));
+						}
+					}
 				}
 				if (_theBoard.squares[_rank][_file - 1] != null 
 				    && lastMove != null
@@ -863,7 +916,7 @@ class Position {
 				    && _theBoard.squares[_rank][_file - 1] == lastMove.pieceMoved
 				    && Math.abs(lastMove.oldRank - lastMove.newRank) == 2) {
 					// Create a new Move represent the this move
-					Move newMove = new Move (_rank, _file, _rank + rankOffset, _file - 1, _theBoard);
+					Move newMove = new Move (_rank, _file, _rank + rankOffset, _file - 1, 0, _theBoard);
 					
 					// Discard this move and any further repetitions if the move results in the
 					// player's king being in check.
@@ -876,12 +929,27 @@ class Position {
 			if (_file + 1 < 8) {
 				if (_theBoard.squares[_rank + rankOffset][_file + 1] != null &&  _theBoard.squares[_rank + rankOffset][_file + 1].colour != colour) {
 					// Create a new Move represent the this move
-					Move newMove = new Move(_rank, _file, _rank + rankOffset, _file + 1, _theBoard);
-				
-					// Discard this move and any further repetitions if the move results in the
-					// player's king being in check.
-					if (_theBoard.MoveIntoCheck(newMove) == false)
-						possibleMoves.add(newMove);					
+					if (_rank + rankOffset != 0 && _rank + rankOffset != 7) {
+						// The pawn does not promote this move
+						Move newMove = new Move(_rank, _file, _rank + rankOffset, _file + 1, 0, _theBoard);
+					
+						// Discard this move and any further repetitions if the move results in the
+						// player's king being in check.
+						if (_theBoard.MoveIntoCheck(newMove) == false)
+							possibleMoves.add(newMove);
+					} else {
+						// The pawn would promote with this move
+						Move newMove = new Move(_rank, _file, _rank + rankOffset, _file + 1, 2, _theBoard);
+						
+						// Discard this move and any further repetitions if the move results in the
+						// player's king being in check.
+						// Otherwise, add the rest of the promotion possibilities to the list of moves.
+						if (_theBoard.MoveIntoCheck(newMove) == false) {
+							possibleMoves.add(newMove);
+							for (int promotionNumber = 3; promotionNumber <= 5; promotionNumber++)
+								possibleMoves.add(new Move(_rank, _file, _rank + rankOffset, _file + 1, promotionNumber, _theBoard));
+						}
+					}	
 				}
 				if (_theBoard.squares[_rank][_file + 1] != null 
 				    && lastMove != null
@@ -890,7 +958,7 @@ class Position {
 				    && _theBoard.squares[_rank][_file + 1] == lastMove.pieceMoved
 				    && Math.abs(lastMove.oldRank - lastMove.newRank) == 2) {
 					// Create a new Move represent the this move
-					Move newMove = new Move (_rank, _file, _rank + rankOffset, _file + 1, _theBoard);
+					Move newMove = new Move (_rank, _file, _rank + rankOffset, _file + 1, 0, _theBoard);
 					
 					// Discard this move and any further repetitions if the move results in the
 					// player's king being in check.
@@ -940,7 +1008,7 @@ class Position {
 			icon += "bishop.png";
 			
 			// These are the standard moves a bishop can make. 
-		    standardMoves = new PieceMove[4];
+		    	standardMoves = new PieceMove[4];
 			standardMoves[0] = new PieceMove(-1, -1, true);
 			standardMoves[1] = new PieceMove(-1, 1, true);
 			standardMoves[2] = new PieceMove(1, -1, true);
@@ -963,7 +1031,7 @@ class Position {
 			icon += "rook.png";
 			
 			// These are the standard moves a rook can make. 
-		    standardMoves = new PieceMove[4];
+		    	standardMoves = new PieceMove[4];
 			standardMoves[0] = new PieceMove(-1, 0, true);
 			standardMoves[1] = new PieceMove(1, 0, true);
 			standardMoves[2] = new PieceMove(0, -1, true);
@@ -1013,7 +1081,7 @@ class Position {
 			icon += "king.png";
 			
 			// These are the standard moves a king can make. 
-		        standardMoves = new PieceMove[8];
+		    	standardMoves = new PieceMove[8];
 			standardMoves[0] = new PieceMove(-1, -1, false);
 			standardMoves[1] = new PieceMove(-1, 0, false);
 			standardMoves[2] = new PieceMove(-1, 1, false);
@@ -1040,7 +1108,7 @@ class Position {
 								!_theBoard.SquareAttacked(7, 3, colour)) {
 								
 								// Queenside castling is okay so create a Position for the move
-								Move newMove = new Move(7, 4, 7, 2, _theBoard);
+								Move newMove = new Move(7, 4, 7, 2, 0, _theBoard);
 								newMove.castling = Move.QUEEN_SIDE;
 
 								// Add the move to the list
@@ -1057,7 +1125,7 @@ class Position {
 								!_theBoard.SquareAttacked(7, 6, colour)) {
 								
 								// King-side castling is okay so create a Position for the move
-								Move newMove = new Move(7, 4, 7, 6, _theBoard);
+								Move newMove = new Move(7, 4, 7, 6, 0, _theBoard);
 								newMove.castling = Move.KING_SIDE;
 
 								// Add the move to the list
@@ -1076,7 +1144,7 @@ class Position {
 								!_theBoard.SquareAttacked(0, 3, colour)) {
 								
 								// Queen-side castling is okay so create a Position for the move
-								Move newMove = new Move(0, 4, 0, 2, _theBoard);
+								Move newMove = new Move(0, 4, 0, 2, 0, _theBoard);
 								newMove.castling = Move.QUEEN_SIDE;
 
 								// Add the move to the list
@@ -1093,7 +1161,7 @@ class Position {
 								!_theBoard.SquareAttacked(0, 6, colour)) {
 								
 								// King-side castling is okay so create a Position for the move
-								Move newMove = new Move(0, 4, 0, 6, _theBoard);
+								Move newMove = new Move(0, 4, 0, 6, 0, _theBoard);
 								newMove.castling = Move.KING_SIDE;
 
 								// Add the move to the list

--- a/src/net/animats/chess/XBoardInterface.java
+++ b/src/net/animats/chess/XBoardInterface.java
@@ -109,7 +109,7 @@ class XBoardInterface implements IOInterface {
 	 * regarding the engine's thinking is to be displayed.
 	 */
 	public void Thinking(int _ply, int _evaluation, double _time, int _nodes, String _line){
-		System.out.println("" + _ply + " " + _evaluation + " " + (long) _time + " " + _nodes + " " + _line);
+		System.out.println("" + _ply + " " + _evaluation + " " + (long)(_time / 10) + " " + _nodes + " " + _line);
 	}
 
 	/**
@@ -122,7 +122,7 @@ class XBoardInterface implements IOInterface {
 
 	/**
 	 * This method is called when the board has changed and
-	 * the display needs to be updated to relfect the change.
+	 * the display needs to be updated to reflect the change.
 	 * It takes a single parameter that is a reference to a
 	 * <code>Position</code> object representing the new
 	 * state of the board.


### PR DESCRIPTION
Added proper Xboard support for promotion (adding the letter of the piece to become at the end of the command).
Added the underpromotions to the list of legal moves and supported them (so the engine could use them properly).
Added a new OptionDialog to select the piece to promote to (for human players using the Swing interface).
Correct Xboard output to give time in centiseconds and Swing/Console output to number moves correctly.